### PR TITLE
catch QR code generation exceptions

### DIFF
--- a/export-xml.html
+++ b/export-xml.html
@@ -110,7 +110,11 @@ function parsexml(param) {
     uri='otpauth://'+j['type'].toLowerCase()+'/'+encodeURIComponent(label)+'?'+querydata(param);
     console.log(uri);
     document.getElementById("file").insertAdjacentHTML('afterend', '<p><div>'+name+'</div><div id="'+i+'"></div>' );
-    new QRCode(document.getElementById(i),uri);
+    try {
+      new QRCode(document.getElementById(i),uri);
+    } catch(err) {
+      console.log(err);
+    }
   }
 }
  

--- a/export.html
+++ b/export.html
@@ -113,7 +113,11 @@ function parsexml(param) {
     uri='otpauth://'+j['type'].toLowerCase()+'/'+encodeURIComponent(label)+'?'+querydata(param);
     console.log(uri);
     document.getElementById("file").insertAdjacentHTML('afterend', '<p><div>'+name+'</div><div id="'+i+'"></div>' );
-    new QRCode(document.getElementById(i),uri);
+    try {
+      new QRCode(document.getElementById(i),uri);
+    } catch(err) {
+      console.log(err);
+    }
   }
 }
  


### PR DESCRIPTION
Error: code length overflow. (1748>1056)
    at Function.b.createData (qrcode.min.js:1)
    at b.makeImpl (qrcode.min.js:1)
    at b.getBestMaskPattern (qrcode.min.js:1)
    at b.make (qrcode.min.js:1)
    at QRCode.makeCode (qrcode.min.js:1)
    at new QRCode (qrcode.min.js:1)
    at parsexml (export-xml.html:114)
    at FileReader.reader.onload (export-xml.html:134)

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>